### PR TITLE
JavaScript, TypeScript 문제풀이를 위한 프로젝트 세팅 (2)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'airbnb-base',
+    'airbnb-typescript/base'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -40,6 +41,5 @@ module.exports = {
     'object-curly-spacing': ['error', 'always'],
     'key-spacing': ['error', { mode: 'strict' }],
     'arrow-spacing': ['error', { before: true, after: true }],
-    'import/no-extraneous-dependencies': 'off',
   },
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,5 @@
 module.exports = {
-
+  transform: {
+    '^.+\\.(t|j)sx?$': '@swc/jest',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -19,12 +19,15 @@
   },
   "homepage": "https://github.com/hsjkdss228/daily-coding-dojo#readme",
   "devDependencies": {
+    "@swc/core": "^1.3.83",
+    "@swc/jest": "^0.2.29",
     "@types/jest": "^29.5.4",
     "@types/node": "^20.6.0",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
     "eslint": "^8.49.0",
     "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-plugin-import": "^2.28.1",
     "jest": "^29.6.4",
     "typescript": "^5.2.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "target": "esnext",
     "allowJs": true,
     "checkJs": true,
-    "noImplicitAny": false,
+    "strict": true,
     "types": [
       "@types/node",
       "@types/jest",


### PR DESCRIPTION
# 이슈
- @swc/core, @swc/jest 의존성 추가
  - .test.ts 소스코드 실행 시 @swc/jest를 통해 컴파일
- eslint-config-airbnb-typescript 의존성 추가
  - 다음의 TypeScript import ESLint 오류 해결
    - Unable to resolve path to module
    - Missing file extension "ts" import/extensions
- tsconfig.json에 다음의 의존성 추가
  - "compilerOptions": "target": "esnext"
  - TypeScript 소스코드 컴파일 시 JavaScript의 ECMAScript 최신 버전을 대상으로 지정

# Reference
- <https://www.npmjs.com/package/@swc/jest>
- <https://stackoverflow.com/questions/55198502/using-eslint-with-typescript-unable-to-resolve-path-to-module>
- <https://stackoverflow.com/questions/59265981/typescript-eslint-missing-file-extension-ts-import-extensions>
- <https://www.npmjs.com/package/eslint-config-airbnb-typescript>